### PR TITLE
Release v1.1.0: Restore/clean up CFN-managed dashboards via EventBridge

### DIFF
--- a/bin/on-demand-dashboard.ts
+++ b/bin/on-demand-dashboard.ts
@@ -3,6 +3,7 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import {Duration} from 'aws-cdk-lib';
 import {OnDemandDashboardStack} from '../lib/on-demand-dashboard-stack';
+import {TestDashboardStack} from '../lib/test-dashboard-stack';
 import {TOnDemandDashboardRule} from "../lib/lambda/types";
 
 type PresetRuleName = "Demo1" | "Demo2" | "AllManualExceptODD" | "AllEnabledExceptODD" | "AllEnabled" | "AllDisabled"
@@ -90,3 +91,5 @@ new OnDemandDashboardStack(app, 'OnDemandDashboard', {
         showAdminDashboard: true,
     }
 });
+
+new TestDashboardStack(app, 'TestDashboard');

--- a/lib/lambda/ApiClient.ts
+++ b/lib/lambda/ApiClient.ts
@@ -119,11 +119,19 @@ export class ApiClient implements IApiClient {
 
     async deleteCloudwatch(dashboardName: string) {
         const {cloudWatch} = this
-        await cloudWatch.send(new DeleteDashboardsCommand({
-            DashboardNames: [
-                dashboardName
-            ]
-        }))
+        try {
+            await cloudWatch.send(new DeleteDashboardsCommand({
+                DashboardNames: [
+                    dashboardName
+                ]
+            }))
+        } catch (e) {
+            if (isErrorWithName(e) && e.name === 'ResourceNotFound') {
+                return
+            }
+            this.logger.warn(`${e}`)
+            throw e
+        }
     }
 
     async archiveToCloudWatch(dashboardName: string) {

--- a/lib/lambda/StackEventHandler.ts
+++ b/lib/lambda/StackEventHandler.ts
@@ -1,0 +1,103 @@
+import {Logger} from "@aws-lambda-powertools/logger";
+import {CloudFormationClient, DescribeStackResourcesCommand} from "@aws-sdk/client-cloudformation";
+import {IApiClient} from "./ApiClient";
+
+export type TCfnStackEvent = {
+    detail: {
+        "stack-id"?: string,
+        "status-details"?: {
+            status?: string,
+        },
+    }
+}
+
+const DASHBOARD_RESOURCE_TYPE = "AWS::CloudWatch::Dashboard"
+
+const RESTORE_STATUSES = new Set([
+    "UPDATE_IN_PROGRESS",
+])
+
+const CLEANUP_STATUSES = new Set([
+    "DELETE_IN_PROGRESS",
+    "DELETE_COMPLETE",
+])
+
+export interface ICfnClient {
+    listDashboardNames(stackId: string): Promise<string[]>
+}
+
+export class CfnClient implements ICfnClient {
+    readonly client: CloudFormationClient
+    readonly logger: Logger
+
+    constructor(params: { region: string, logger: Logger }) {
+        this.client = new CloudFormationClient({region: params.region})
+        this.logger = params.logger
+    }
+
+    async listDashboardNames(stackId: string): Promise<string[]> {
+        const {StackResources} = await this.client.send(new DescribeStackResourcesCommand({
+            StackName: stackId,
+        }))
+        return (StackResources ?? [])
+            .filter(r => r.ResourceType === DASHBOARD_RESOURCE_TYPE)
+            .map(r => r.PhysicalResourceId)
+            .filter((id): id is string => !!id)
+    }
+}
+
+export class StackEventHandler {
+    readonly logger: Logger
+    readonly cfn: ICfnClient
+    readonly api: IApiClient
+
+    constructor(params: {
+        cfn: ICfnClient,
+        api: IApiClient,
+        logger: Logger,
+    }) {
+        this.cfn = params.cfn
+        this.api = params.api
+        this.logger = params.logger
+    }
+
+    async handle(event: TCfnStackEvent): Promise<void> {
+        const stackId = event.detail?.["stack-id"]
+        const status = event.detail?.["status-details"]?.status
+        if (!stackId || !status) {
+            this.logger.warn("Missing stack-id or status", {event})
+            return
+        }
+        const isRestore = RESTORE_STATUSES.has(status)
+        const isCleanup = CLEANUP_STATUSES.has(status)
+        if (!isRestore && !isCleanup) {
+            return
+        }
+
+        const dashboardNames = await this.cfn.listDashboardNames(stackId)
+        if (dashboardNames.length === 0) {
+            return
+        }
+        this.logger.info("Processing stack event", {stackId, status, dashboardNames})
+
+        for (const dashboardName of dashboardNames) {
+            if (isRestore) {
+                // Restore from archive so CFN can update the dashboard.
+                // archiveToCloudWatch is a no-op when there is no archive entry.
+                await this.api.archiveToCloudWatch(dashboardName)
+                this.logger.info("Restored dashboard", {dashboardName, status})
+            } else {
+                // Force-delete both the CloudWatch dashboard and the S3 archive.
+                // We cannot rely on CFN's own deletion because of the race against
+                // restore: if a restore happened to win against CFN's deleteDashboard
+                // (or against an earlier UPDATE_IN_PROGRESS restore), a dashboard the
+                // user intended to delete would otherwise remain.
+                await Promise.all([
+                    this.api.deleteCloudwatch(dashboardName),
+                    this.api.deleteArchive(dashboardName),
+                ])
+                this.logger.info("Deleted dashboard and archive", {dashboardName, status})
+            }
+        }
+    }
+}

--- a/lib/lambda/lambda-stack-event.ts
+++ b/lib/lambda/lambda-stack-event.ts
@@ -1,0 +1,34 @@
+import type {LambdaInterface} from '@aws-lambda-powertools/commons/types';
+import {Logger} from '@aws-lambda-powertools/logger'
+import {Context} from 'aws-lambda'
+import {ApiClient} from "./ApiClient"
+import {CfnClient, StackEventHandler, TCfnStackEvent} from "./StackEventHandler"
+
+export type StackEventLambdaEnv = {
+    BUCKET_NAME: string,
+}
+
+const env = process.env as StackEventLambdaEnv & {
+    AWS_REGION: string
+}
+
+const logger = new Logger({
+    serviceName: 'stack-event',
+});
+
+const stackEventHandler = new StackEventHandler({
+    cfn: new CfnClient({region: env.AWS_REGION, logger}),
+    api: new ApiClient({region: env.AWS_REGION, bucketName: env.BUCKET_NAME, logger}),
+    logger,
+})
+
+class Lambda implements LambdaInterface {
+    @logger.injectLambdaContext({logEvent: false, resetKeys: true})
+    public async handler(event: TCfnStackEvent, context: Context): Promise<void> {
+        logger.appendKeys({event, context})
+        await stackEventHandler.handle(event)
+    }
+}
+
+const f = new Lambda()
+export const handler = f.handler.bind(f)

--- a/lib/lambda/types.ts
+++ b/lib/lambda/types.ts
@@ -30,6 +30,7 @@ export type TOnDemandDashboardOptions = {
         readonly bucket?: string
         readonly dashboardLambda?: string,
         readonly redirectLambda?: string
+        readonly stackEventLambda?: string
     }
     readonly version: string
 }

--- a/lib/on-demand-dashboard-stack.ts
+++ b/lib/on-demand-dashboard-stack.ts
@@ -13,6 +13,7 @@ import {FunctionUrl} from "aws-cdk-lib/aws-lambda/lib/function-url";
 import {merge} from 'lodash'
 import {RedirectLambdaEnv} from "./lambda/lambda-redirect";
 import {DashboardLambdaEnv} from "./lambda/lambda-dashboard";
+import {StackEventLambdaEnv} from "./lambda/lambda-stack-event";
 import {TOnDemandDashboardOptions} from "./lambda/types";
 import {DashboardManager, TAction} from "./lambda/DashboardManager";
 
@@ -70,6 +71,16 @@ export class OnDemandDashboardStack extends cdk.Stack {
                         ]
                     })]
                 }),
+                cloudformation: new PolicyDocument({
+                    statements: [new PolicyStatement({
+                        actions: [
+                            "cloudformation:DescribeStackResources",
+                        ],
+                        resources: [
+                            "*"
+                        ]
+                    })]
+                }),
                 s3: new PolicyDocument({
                     statements: [
                         new PolicyStatement({
@@ -106,6 +117,11 @@ export class OnDemandDashboardStack extends cdk.Stack {
             bucket,
             role,
             redirectUrl,
+        })
+
+        const {fn: stackEventFn, logGroup: stackEventLogGroup} = this.createStackEventHandler({
+            bucket,
+            role,
         })
 
 
@@ -148,6 +164,7 @@ export class OnDemandDashboardStack extends cdk.Stack {
                                     `role|${role.roleName}`,
                                     `dashboard lambda|${dashboardFn.functionName}`,
                                     `redirect lambda|${redirectFn.functionName}`,
+                                    `stack event lambda|${stackEventFn.functionName}`,
                                 )
 
                                 lines.push("")
@@ -201,6 +218,7 @@ export class OnDemandDashboardStack extends cdk.Stack {
                             logGroupNames: [
                                 dashboardLogGroup.logGroupName,
                                 redirectLogGroup.logGroupName,
+                                stackEventLogGroup.logGroupName,
                             ]
                         }),
                     ]
@@ -304,6 +322,62 @@ export class OnDemandDashboardStack extends cdk.Stack {
                 event: RuleTargetInput.fromObject({action: scheduledJobAction})
             })],
             schedule: this.options.jobSchedule
+        })
+
+        return {fn, logGroup}
+    }
+
+    createStackEventHandler(params: {
+        readonly bucket: Bucket,
+        readonly role: Role,
+    }): {
+        fn: NodejsFunction,
+        logGroup: LogGroup,
+    } {
+        const {role, bucket} = params
+
+        function subId(s: string): string {
+            return `stack-event-${s}`
+        }
+
+        const environment: StackEventLambdaEnv = {
+            BUCKET_NAME: bucket.bucketName,
+        }
+
+        const fn = new NodejsFunction(this, subId('fn'), {
+            functionName: this.options.names.stackEventLambda,
+            entry: "lib/lambda/lambda-stack-event.ts",
+            runtime: Runtime.NODEJS_22_X,
+            awsSdkConnectionReuse: true,
+            timeout: Duration.minutes(1),
+            loggingFormat: LoggingFormat.JSON,
+            systemLogLevelV2: SystemLogLevel.INFO,
+            applicationLogLevelV2: ApplicationLogLevel.INFO,
+            environment,
+            role,
+        })
+
+        const logGroup = new LogGroup(this, subId('log-group'), {
+            logGroupName: `/aws/lambda/${fn.functionName}`,
+            removalPolicy: RemovalPolicy.DESTROY,
+            retention: this.options.logRetention,
+        })
+
+        new Rule(this, subId("rule"), {
+            eventPattern: {
+                source: ["aws.cloudformation"],
+                detailType: ["CloudFormation Stack Status Change"],
+                detail: {
+                    "status-details": {
+                        status: [
+                            "UPDATE_IN_PROGRESS",
+                            "DELETE_IN_PROGRESS",
+                            "DELETE_COMPLETE",
+                        ],
+                    },
+                },
+            },
+            targets: [new LambdaFunction(fn)],
         })
 
         return {fn, logGroup}

--- a/lib/test-dashboard-stack.ts
+++ b/lib/test-dashboard-stack.ts
@@ -1,0 +1,41 @@
+import * as cdk from 'aws-cdk-lib';
+import {Construct} from 'constructs';
+import {Dashboard, TextWidget} from "aws-cdk-lib/aws-cloudwatch";
+
+/**
+ * Minimal stack used to exercise the EventBridge restore flow.
+ *
+ * Deploy:        cdk deploy TestDashboard
+ * Evacuate:      use the OnDemandDashboard UI to "Deactivate" "TestDashboard"
+ *                (dashboard is moved out of CloudWatch into the S3 archive)
+ * Update test:   cdk deploy TestDashboard -c testDashboardLabel=v2
+ *                (without restore: CFN update fails because the dashboard is gone)
+ * Delete test:   cdk destroy TestDashboard
+ *                (the S3 archive should be cleaned up on DELETE_COMPLETE)
+ */
+export class TestDashboardStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        const label = this.node.tryGetContext("testDashboardLabel") ?? "v1"
+
+        new Dashboard(this, 'test-dashboard', {
+            dashboardName: "TestDashboard",
+            widgets: [
+                [
+                    new TextWidget({
+                        width: 24,
+                        height: 4,
+                        markdown: [
+                            "# TestDashboard",
+                            "",
+                            `label: **${label}**`,
+                            "",
+                            "Used to verify the EventBridge restore flow.",
+                        ].join("\n"),
+                    }),
+                ],
+            ],
+        })
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "on-demand-dashboard",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "on-demand-dashboard",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.28.1",
+        "@aws-sdk/client-cloudformation": "^3.1050.0",
         "@aws-sdk/client-cloudwatch": "^3.927.0",
         "@aws-sdk/client-lambda": "^3.927.0",
         "@aws-sdk/client-s3": "^3.927.0",
@@ -312,6 +313,289 @@
         "@middy/core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation": {
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1050.0.tgz",
+      "integrity": "sha512-x9cPw8T+6Bvpf+SlY/osVXVzIPzuJhtS3Bn/MG7QOgxGCmdaSC81U7Jc18VyS/b4ogJ6iwU+FCu5wmnMyMLfXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/core": {
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-login": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-ini": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/token-providers": "3.1049.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
@@ -621,6 +905,137 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
@@ -2544,6 +2959,18 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2651,20 +3078,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.2.tgz",
-      "integrity": "sha512-n3g4Nl1Te+qGPDbNFAYf+smkRVB+JhFsGy9uJXXZQEufoP4u0r+WLh6KvTDolCswaagysDc/afS1yvb2jnj1gQ==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.4",
-        "@smithy/util-stream": "^4.5.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2672,15 +3092,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.4.tgz",
-      "integrity": "sha512-YVNMjhdz2pVto5bRdux7GMs0x1m0Afz3OcQy/4Yf9DH4fWOtroGH7uLvs7ZmDyoBJzLdegtIPpXrpJOZWvUXdw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.4",
-        "@smithy/property-provider": "^4.2.4",
-        "@smithy/types": "^4.8.1",
-        "@smithy/url-parser": "^4.2.4",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2758,15 +3176,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.5.tgz",
-      "integrity": "sha512-mg83SM3FLI8Sa2ooTJbsh5MFfyMTyNRwxqpKHmE0ICRIa66Aodv80DMsTQI02xBLVJ0hckwqTRr5IGAbbWuFLQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/querystring-builder": "^4.2.4",
-        "@smithy/types": "^4.8.1",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2973,15 +3389,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.4.tgz",
-      "integrity": "sha512-VXHGfzCXLZeKnFp6QXjAdy+U8JF9etfpUXD1FAbzY1GzsFJiDQRQIt2CnMUvUdz3/YaHNqT3RphVWMUpXTIODA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.4",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/querystring-builder": "^4.2.4",
-        "@smithy/types": "^4.8.1",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3008,20 +3422,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.8.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.4.tgz",
-      "integrity": "sha512-KQ1gFXXC+WsbPFnk7pzskzOpn4s+KheWgO3dzkIEmnb6NskAIGp/dGdbKisTPJdtov28qNDohQrgDUKzXZBLig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.8.1",
-        "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3067,18 +3467,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.4.tgz",
-      "integrity": "sha512-ScDCpasxH7w1HXHYbtk3jcivjvdA1VICyAdgvVqKhKKwxi+MTwZEqFw0minE+oZ7F07oF25xh4FGJxgqgShz0A==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.4",
-        "@smithy/types": "^4.8.1",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.4",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3104,9 +3499,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.1.tgz",
-      "integrity": "sha512-N0Zn0OT1zc+NA+UVfkYqQzviRh5ucWwO7mBV3TmHHprMnfcJNfhlPicDkBHi0ewbh+y3evR6cNAW0Raxvb01NA==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3291,18 +3686,6 @@
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5178,6 +5561,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -6899,6 +7298,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -7404,9 +7818,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -8013,6 +8427,21 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "on-demand-dashboard",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "bin": {
     "cdk-on-demand-dashboard": "bin/on-demand-dashboard.js"
   },
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.28.1",
+    "@aws-sdk/client-cloudformation": "^3.1050.0",
     "@aws-sdk/client-cloudwatch": "^3.927.0",
     "@aws-sdk/client-lambda": "^3.927.0",
     "@aws-sdk/client-s3": "^3.927.0",

--- a/test/StackEventHandler.test.ts
+++ b/test/StackEventHandler.test.ts
@@ -1,0 +1,118 @@
+import {Logger} from "@aws-lambda-powertools/logger";
+import {ICfnClient, StackEventHandler, TCfnStackEvent} from "../lib/lambda/StackEventHandler";
+import {IApiClient, TDashboardEntry} from "../lib/lambda/ApiClient";
+
+class FakeCfnClient implements ICfnClient {
+    constructor(readonly mapping: { [stackId: string]: string[] }) {
+    }
+
+    async listDashboardNames(stackId: string): Promise<string[]> {
+        return this.mapping[stackId] ?? []
+    }
+}
+
+class FakeApiClient implements IApiClient {
+    readonly restored: string[] = []
+    readonly deletedArchives: string[] = []
+    readonly deletedDashboards: string[] = []
+
+    async archiveToCloudWatch(dashboardName: string): Promise<void> {
+        this.restored.push(dashboardName)
+    }
+
+    async deleteArchive(dashboardName: string): Promise<void> {
+        this.deletedArchives.push(dashboardName)
+    }
+
+    async deleteCloudwatch(dashboardName: string): Promise<void> {
+        this.deletedDashboards.push(dashboardName)
+    }
+
+    async cloudWatchToArchive(): Promise<void> {
+    }
+
+    async loadEntriesFromArchive(): Promise<TDashboardEntry[]> {
+        return []
+    }
+
+    async loadEntriesFromCloudWatch(): Promise<TDashboardEntry[]> {
+        return []
+    }
+}
+
+function newHandler(mapping: { [stackId: string]: string[] }) {
+    const cfn = new FakeCfnClient(mapping)
+    const api = new FakeApiClient()
+    const logger = new Logger({serviceName: 'test'})
+    const handler = new StackEventHandler({cfn, api, logger})
+    return {cfn, api, handler}
+}
+
+function newEvent(stackId: string, status: string): TCfnStackEvent {
+    return {
+        detail: {
+            "stack-id": stackId,
+            "status-details": {status},
+        }
+    }
+}
+
+const stackId = "arn:aws:cloudformation:us-east-1:111111111111:stack/my-stack/abc"
+
+test('UPDATE_IN_PROGRESS restores each dashboard belonging to the stack', async () => {
+    const {api, handler} = newHandler({[stackId]: ["DashA", "DashB"]})
+    await handler.handle(newEvent(stackId, "UPDATE_IN_PROGRESS"))
+    expect(api.restored).toEqual(["DashA", "DashB"])
+    expect(api.deletedArchives).toEqual([])
+    expect(api.deletedDashboards).toEqual([])
+})
+
+test('DELETE_IN_PROGRESS force-deletes each dashboard and its archive', async () => {
+    const {api, handler} = newHandler({[stackId]: ["DashA"]})
+    await handler.handle(newEvent(stackId, "DELETE_IN_PROGRESS"))
+    expect(api.restored).toEqual([])
+    expect(api.deletedDashboards).toEqual(["DashA"])
+    expect(api.deletedArchives).toEqual(["DashA"])
+})
+
+test('DELETE_COMPLETE force-deletes each dashboard and its archive', async () => {
+    const {api, handler} = newHandler({[stackId]: ["DashA", "DashB"]})
+    await handler.handle(newEvent(stackId, "DELETE_COMPLETE"))
+    expect(api.restored).toEqual([])
+    expect(api.deletedDashboards).toEqual(["DashA", "DashB"])
+    expect(api.deletedArchives).toEqual(["DashA", "DashB"])
+})
+
+test('Other statuses are ignored', async () => {
+    const {api, handler} = newHandler({[stackId]: ["DashA"]})
+    await handler.handle(newEvent(stackId, "CREATE_COMPLETE"))
+    await handler.handle(newEvent(stackId, "UPDATE_COMPLETE"))
+    await handler.handle(newEvent(stackId, "ROLLBACK_IN_PROGRESS"))
+    expect(api.restored).toEqual([])
+    expect(api.deletedArchives).toEqual([])
+    expect(api.deletedDashboards).toEqual([])
+})
+
+test('No dashboards in stack is a no-op', async () => {
+    const {api, handler} = newHandler({[stackId]: []})
+    await handler.handle(newEvent(stackId, "UPDATE_IN_PROGRESS"))
+    expect(api.restored).toEqual([])
+    expect(api.deletedArchives).toEqual([])
+    expect(api.deletedDashboards).toEqual([])
+})
+
+test('Missing stack-id is a no-op', async () => {
+    const {api, handler} = newHandler({})
+    await handler.handle({detail: {"status-details": {status: "UPDATE_IN_PROGRESS"}}})
+    expect(api.restored).toEqual([])
+    expect(api.deletedArchives).toEqual([])
+    expect(api.deletedDashboards).toEqual([])
+})
+
+test('Missing status is a no-op', async () => {
+    const {api, handler} = newHandler({[stackId]: ["DashA"]})
+    await handler.handle({detail: {"stack-id": stackId}})
+    expect(api.restored).toEqual([])
+    expect(api.deletedArchives).toEqual([])
+    expect(api.deletedDashboards).toEqual([])
+})


### PR DESCRIPTION
## Summary
Promote v1.1.0 from develop to main.

Includes #9 (closes #8):
- New `stack-event` Lambda subscribed to `CloudFormation Stack Status Change`
- `UPDATE_IN_PROGRESS` → restore evacuated dashboard from S3 archive so CFN update succeeds
- `DELETE_IN_PROGRESS` / `DELETE_COMPLETE` → force-delete both the CloudWatch dashboard and its archive (race-safe)
- IAM: add `cloudformation:DescribeStackResources`
- Bump version to 1.1.0
- Add `TestDashboardStack` for manual verification

## Test plan
- [x] Unit tests pass
- [x] Manual end-to-end on develop branch: evacuate → destroy → both CW dashboard and S3 archive cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)